### PR TITLE
26713: Include on-demand CVMFS provisioning info in GWMS documentation

### DIFF
--- a/doc/factory/custom_vars.html
+++ b/doc/factory/custom_vars.html
@@ -2533,6 +2533,84 @@ MAX_STARTD_LOG          I       10000000        +                               
           </tr>
         </table>
       </div>
+      
+      <div class="section">
+        <h3><a name="cvmfs_vars"></a>CVMFS Variables</h3>
+        <p>
+          This section describes the variables that can be configured for 
+          use with the glidein to allow CVMFS to be provisioned on-demand. 
+          These variables are configured at the glidein level so that it 
+          applies to all the entries that are configured in the factory's 
+          configuration file.
+        </p>
+        <table class="attributes">
+          <tr class="head">
+            <td>
+              <p><b>Name</b></p>
+            </td>
+            <td>
+              <p><b>Type</b></p>
+            </td>
+            <td>
+              <p><b>Default Value</b></p>
+            </td>
+            <td>
+              <p><b>Where</b></p>
+            </td>
+            <td>
+              <p><b>Description</b></p>
+            </td>
+          </tr>
+          <tr>
+            <td><b>GLIDEIN_USE_CVMFSEXEC</b></td>
+            <td>Int</td>
+            <td></td>
+            <td>Factory</td>
+            <td>
+              <p>Not set by default. This variable controls whether 
+                <i>cvmfsexec</i> utility is used to mount CVMFS. Possible 
+                values are 0 or 1. A value of 0 indicates that 
+                glidein will not use <i>cvmfsexec</i> to mount CVMFS on the 
+                worker noden. A value of 1 indicates <i>cvmfsexec</i> will 
+                be used to mount CVMFS on the worker node by the glidein.</p>
+            </td>
+          </tr>
+          <tr>
+            <td><b>CVMFS_SRC</b></td>
+            <td>String</td>
+            <td></td>
+            <td>Factory</td>
+            <td>
+              <p>Not set by default. This variable controls the origin (source)
+                from which to download the CVMFS configuration repository 
+                from. Possible values are: <br/>
+                osg - configuration for cvmfs-config-osg; <br/>
+                egi - configuration for cvmfs-config-egi; <br/>
+                default - configuration for cvmfs-config-default<br/>
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <td><b>GLIDEIN_CVMFS</b></td>
+            <td>String</td>
+            <td></td>
+            <td>Factory</td>
+            <td>
+              <p>Not set by default. This variable controls the 
+                error handling behavior of the glidein in case of failures 
+                during the mounting of CVMFS. Possible values are:<br/>
+                REQUIRED - if unable to mount, report an error and abort 
+                mounting);<br/>
+                PREFERRED - if unable to mount, notify and continue 
+                normally;<br/>
+                OPTIONAL - continue if unable to mount (similar to 
+                PREFERRED);<br/>
+                NEVER - only exit if mounting fails<br/>
+              </p>
+            </td>
+          </tr>
+        </table>
+      </div>
 
       <div class="section">
         <h3><a name="glidein_vars"></a>Glidein Script Variables (dynamic)</h3>

--- a/doc/factory/custom_vars.html
+++ b/doc/factory/custom_vars.html
@@ -2610,6 +2610,51 @@ MAX_STARTD_LOG          I       10000000        +                               
             </td>
           </tr>
         </table>
+        <br/>
+        <h4>Dynamic creation and selection of cvmfsexec 
+          platform-specific distribution</h4>
+        <p>
+          GlideinWMS factory includes the capability to mount and unmount 
+          CVMFS on demand, i.e. for sites that do not have a local 
+          installation of CVMFS available. This is achieved via the scripts 
+          <b>cvmfs_setup.sh</b> and <b>cvmfs_umount.sh</b>. Two additional 
+          shell scripts <i>cvmfs_helper_funcs.sh</i> and <i>cvmfs_mount
+          .sh</i> are used as helper scripts during the mounting process. On 
+          demand mounting and unmounting is achieved via the <b><i>cvmfsexec
+          </i></b> utility. The helper scripts are enabled for conditional 
+          download based on the GLIDEIN_USE_CVMFSEXEC variable. When the 
+          GLIDEIN_USE_CVMFSEXEC variable is set (value of 1), the helper 
+          scripts are downloaded for facilitating the mounting of CVMFS. 
+        </p>
+        <p>
+          cvmfsexec can be packaged as self-contained distribution specific 
+          to an operating system and platform with required configuration and 
+          executables necessary to enable CVMFS in unprivileged mode. Doing 
+          so allows easy distribution to multiple machines. Worker 
+          node specifications vary from each other and can change over 
+          time so, shipping all possible variations of cvmfsexec 
+          distributions with the glidein helps address the challenge when it
+          comes to using the correct distribution for use by the worker 
+          node. However, rather than having a tarball containing multiple 
+          cvmfsexec distribution files corresponding to a (CVMFS source, 
+          system platform, architecture) combination, GlideinWMS dynamically 
+          creates and selects the appropriate cvmfsexec distribution from 
+          the list of distributions.
+        </p>
+        <p>
+          Specific to a CVMFS source, system platform and architecture, 
+          cvmfsexec distribution files are created automatically by the script 
+          named <b>create_cvmfsexec_distros.sh</b>. The script is placed in 
+          <i>hooks.reconfig.pre</i> directory for dynamic execution. Each of
+          these distributions are packaged as individual tarballs and are 
+          added to the default list of uploads at the time of factory 
+          reconfiguration and/or upgrade. Another script, <i>
+          cvmfsexec_platform_select.sh</i>, automatically selects the 
+          appropriate distribution tarball based on the specifics of the 
+          worker node and ships the distribution with the glidein. This script
+          is invoked during the customization of the worker node as part of 
+          the glidein setup.
+        </p>
       </div>
 
       <div class="section">


### PR DESCRIPTION
Added documentation regarding on-demand CVMFS (the internal specifics) and how the dynamic creation/selection of the cvmfsexec distribution takes place.