### PR TITLE
26094: Automating the creation of platform-specific cvmfs distribution

### DIFF
--- a/build/packaging/rpm/glideinwms.spec
+++ b/build/packaging/rpm/glideinwms.spec
@@ -498,6 +498,8 @@ install -d $RPM_BUILD_ROOT/%{_sysconfdir}/gwms-factory/hooks.reconfig.pre
 install -d $RPM_BUILD_ROOT/%{_sysconfdir}/gwms-factory/hooks.reconfig.post
 install -m 0644 %{SOURCE4} $RPM_BUILD_ROOT/%{_sysconfdir}/gwms-factory/glideinWMS.xml
 install -m 0644 %{SOURCE9} $RPM_BUILD_ROOT/%{_sysconfdir}/sysconfig/gwms-factory
+install -m 0644 creation/web-base/generate_cvmfsexec_distros.sh $RPM_BUILD_ROOT/%{_sysconfdir}/gwms-factory/hooks.reconfig.pre/generate_cvmfsexec_distros.sh
+rm -f creation/web-base/generate_cvmfsexec_distros.sh
 
 # Install the web base
 cp -r creation/web_base/* $RPM_BUILD_ROOT%{web_base}/
@@ -873,6 +875,7 @@ rm -rf $RPM_BUILD_ROOT
 %attr(-, gfactory, gfactory) %dir %{_sysconfdir}/gwms-factory/hooks.reconfig.pre
 %attr(-, gfactory, gfactory) %dir %{_sysconfdir}/gwms-factory/hooks.reconfig.post
 %attr(-, gfactory, gfactory) %config(noreplace) %verify(not md5 mtime size) %{_sysconfdir}/gwms-factory/glideinWMS.xml
+%attr(-, gfactory, gfactory) %{_sysconfdir}/gwms-factory/hooks.reconfig.pre/generate_cvmfsexec_distros.sh
 %config(noreplace) %{_sysconfdir}/sysconfig/gwms-factory
 
 %files vofrontend-core

--- a/build/packaging/rpm/glideinwms.spec
+++ b/build/packaging/rpm/glideinwms.spec
@@ -498,8 +498,9 @@ install -d $RPM_BUILD_ROOT/%{_sysconfdir}/gwms-factory/hooks.reconfig.pre
 install -d $RPM_BUILD_ROOT/%{_sysconfdir}/gwms-factory/hooks.reconfig.post
 install -m 0644 %{SOURCE4} $RPM_BUILD_ROOT/%{_sysconfdir}/gwms-factory/glideinWMS.xml
 install -m 0644 %{SOURCE9} $RPM_BUILD_ROOT/%{_sysconfdir}/sysconfig/gwms-factory
-install -m 0644 creation/web-base/generate_cvmfsexec_distros.sh $RPM_BUILD_ROOT/%{_sysconfdir}/gwms-factory/hooks.reconfig.pre/generate_cvmfsexec_distros.sh
-rm -f creation/web-base/generate_cvmfsexec_distros.sh
+install -m 0755 creation/create_cvmfsexec_distros.sh $RPM_BUILD_ROOT/%{_sysconfdir}/gwms-factory/hooks.reconfig.pre/create_cvmfsexec_distros.sh
+# remove the file from python_sitelib as it is put elsewhere; similar to clone_glidein and info_glidein files
+rm -f $RPM_BUILD_ROOT%{python_sitelib}/glideinwms/creation/create_cvmfsexec_distros.sh
 
 # Install the web base
 cp -r creation/web_base/* $RPM_BUILD_ROOT%{web_base}/
@@ -875,7 +876,7 @@ rm -rf $RPM_BUILD_ROOT
 %attr(-, gfactory, gfactory) %dir %{_sysconfdir}/gwms-factory/hooks.reconfig.pre
 %attr(-, gfactory, gfactory) %dir %{_sysconfdir}/gwms-factory/hooks.reconfig.post
 %attr(-, gfactory, gfactory) %config(noreplace) %verify(not md5 mtime size) %{_sysconfdir}/gwms-factory/glideinWMS.xml
-%attr(-, gfactory, gfactory) %{_sysconfdir}/gwms-factory/hooks.reconfig.pre/generate_cvmfsexec_distros.sh
+%attr(755, gfactory, gfactory) %{_sysconfdir}/gwms-factory/hooks.reconfig.pre/create_cvmfsexec_distros.sh
 %config(noreplace) %{_sysconfdir}/sysconfig/gwms-factory
 
 %files vofrontend-core

--- a/creation/create_cvmfsexec_distros.sh
+++ b/creation/create_cvmfsexec_distros.sh
@@ -32,17 +32,18 @@ if [[ -d $cvmfsexec_temp ]]; then
         latest_ver=`$cvmfsexec_latest/cvmfsexec -v`
         if [[ $curr_ver != $latest_ver ]]; then
             # if current version and latest version are different, use the latest
+            echo "Current version of cvmfsexec: $curr_ver"
             echo "Found newer version of cvmfsexec..."
             rm -rf $cvmfsexec_base
             mv $cvmfsexec_latest $cvmfsexec_base
-            echo "Current version of cvmfsexec: $curr_ver"
             echo "Latest version of cvmfsexec: `$cvmfsexec_base/cvmfsexec -v`"
             echo "Using cvmfsexec version: `$cvmfsexec_base/cvmfsexec -v`"
         else
             # if current version and latest version are the same
-            echo "Current version and latest version are identical!"
+            echo "Current version and latest version of cvmfsexec are identical!"
             echo "cvmfsexec version: `$cvmfsexec_base/cvmfsexec -v`"
             rm -rf $cvmfsexec_latest
+            exit 0
         fi
     else
         # $cvmfsexec_base does not exist
@@ -82,7 +83,6 @@ do
            $cvmfsexec_base/makedist -o $cvmfsexec_distros/cvmfsexec-${cvmfs_src}-${os}-${arch} &> /dev/null
            if [[ -e $cvmfsexec_distros/cvmfsexec-${cvmfs_src}-${os}-${arch} ]]; then
                echo " Success"
-               #echo ""
                tar -cvzf $cvmfsexec_tarballs/cvmfsexec_${cvmfs_src}_${os}_${arch}.tar.gz -C $cvmfsexec_distros cvmfsexec-${cvmfs_src}-${os}-${arch} &> /dev/null
            fi
         else
@@ -92,9 +92,6 @@ do
         # delete the dist directory within cvmfsexec to download the cvmfs configuration
         # and repositories for another machine type
         rm -rf $cvmfsexec_base/dist
-        #echo ""
-        #echo ""
-        #echo ""
     done
 done
 

--- a/creation/create_cvmfsexec_distros.sh
+++ b/creation/create_cvmfsexec_distros.sh
@@ -101,4 +101,4 @@ done
 end=`date +%s`
 
 runtime=$((end-start))
-echo "Took $runtime seconds (the two for-loops)"
+echo "Took $runtime seconds to create the cvmfsexec distributions"

--- a/creation/create_cvmfsexec_distros.sh
+++ b/creation/create_cvmfsexec_distros.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2009 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
+usage() {
+	echo "This script is used to generate cvmfsexec distributions for all"
+	echo "supported machine types (platform- and architecture-based)."
+	echo "The script takes one parameter {osg|egi|default} which specifies"
+	echo "the source to download the latest cvmfs configuration and repositories."
+}
+
+start=`date +%s`
+
+CVMFS_SOURCES=osg:egi:default
+# rhel6-x86_64 is not included; currently not supported due to EOL
+# egi for rhel8-x86_64 results in an error - egi does not yet have a centos8 build (as confirmed with Dave)
+# TODO: verify the logic when egi provides a centos8 build
+SUPPORTED_TYPES=rhel7-x86_64:rhel8-x86_64:suse15-x86_64
+cvmfsexec_temp=/tmp/cvmfsexec_pkg
+cvmfsexec_base=$cvmfsexec_temp/cvmfsexec
+cvmfsexec_latest=$cvmfsexec_temp/latest
+cvmfsexec_distros=$cvmfsexec_temp/distros
+work_dir=/var/lib/gwms-factory/work-dir
+cvmfsexec_tarballs=$work_dir/cvmfsexec/tarballs
+
+if [[ -d $cvmfsexec_temp ]]; then
+#    rm -rf $cvmfsexec_pkg
+    if [[ -d $cvmfsexec_base ]]; then
+        curr_ver=`$cvmfsexec_base/cvmfsexec -v`
+        git clone https://www.github.com/cvmfs/cvmfsexec.git $cvmfsexec_latest &> /dev/null
+        latest_ver=`$cvmfsexec_latest/cvmfsexec -v`
+        if [[ $curr_ver != $latest_ver ]]; then
+            # if current version and latest version are different, use the latest
+            echo "Found newer version of cvmfsexec..."
+            rm -rf $cvmfsexec_base
+            mv $cvmfsexec_latest $cvmfsexec_base
+            echo "Current version of cvmfsexec: $curr_ver"
+            echo "Latest version of cvmfsexec: `$cvmfsexec_base/cvmfsexec -v`"
+            echo "Using cvmfsexec version: `$cvmfsexec_base/cvmfsexec -v`"
+        else
+            # if current version and latest version are the same
+            echo "Current version and latest version are identical!"
+            echo "cvmfsexec version: `$cvmfsexec_base/cvmfsexec -v`"
+            rm -rf $cvmfsexec_latest
+        fi
+    else
+        # $cvmfsexec_base does not exist
+        git clone https://www.github.com/cvmfs/cvmfsexec.git $cvmfsexec_base &> /dev/null
+        echo "cvmfsexec version: `$cvmfsexec_base/cvmfsexec -v`"
+    fi
+else
+    # $cvmfsexec_temp does not exist
+    git clone https://www.github.com/cvmfs/cvmfsexec.git $cvmfsexec_base &> /dev/null
+    echo "cvmfsexec version: `$cvmfsexec_base/cvmfsexec -v`"
+
+fi
+
+if [[ ! -d $cvmfsexec_distros ]]; then
+    mkdir -p $cvmfsexec_distros
+fi
+
+if [[ ! -d $cvmfsexec_tarballs ]]; then
+    mkdir -p $cvmfsexec_tarballs
+fi
+
+declare -a cvmfs_sources
+cvmfs_sources=($(echo $CVMFS_SOURCES | tr ":" "\n"))
+
+declare -a machine_types
+machine_types=($(echo $SUPPORTED_TYPES | tr ":" "\n"))
+
+for cvmfs_src in "${cvmfs_sources[@]}"
+do
+    for mach_type in "${machine_types[@]}"
+    do
+        echo -n "Making $cvmfs_src distribution for $mach_type machine..."
+        os=`echo $mach_type | awk -F'-' '{print $1}'`
+        arch=`echo $mach_type | awk -F'-' '{print $2}'`
+        $cvmfsexec_base/makedist -m $mach_type $cvmfs_src &> /dev/null
+        if [[ $? -eq 0 ]]; then
+           $cvmfsexec_base/makedist -o $cvmfsexec_distros/cvmfsexec-${cvmfs_src}-${os}-${arch} &> /dev/null
+           if [[ -e $cvmfsexec_distros/cvmfsexec-${cvmfs_src}-${os}-${arch} ]]; then
+               echo " Success"
+               #echo ""
+               tar -cvzf $cvmfsexec_tarballs/cvmfsexec_${cvmfs_src}_${os}_${arch}.tar.gz -C $cvmfsexec_distros cvmfsexec-${cvmfs_src}-${os}-${arch} &> /dev/null
+           fi
+        else
+            echo " Failed! REASON: $cvmfs_src may not yet have a $mach_type build."
+        fi
+
+        # delete the dist directory within cvmfsexec to download the cvmfs configuration
+        # and repositories for another machine type
+        rm -rf $cvmfsexec_base/dist
+        #echo ""
+        #echo ""
+        #echo ""
+    done
+done
+
+# TODO: store version information in the $cvmfsexec_tarballs location for future reconfig/upgrade
+#echo "$curr_ver" > $cvmfsexec_tarballs/.version_info
+
+end=`date +%s`
+
+runtime=$((end-start))
+echo "Took $runtime seconds (the two for-loops)"

--- a/creation/lib/cgWConsts.py
+++ b/creation/lib/cgWConsts.py
@@ -27,6 +27,11 @@ CONDOR_ATTR = "CONDOR_DIR"
 
 CONDOR_STARTUP_FILE = "condor_startup.sh"
 
+# constants for cvmfsexec
+CVMFSEXEC_DISTRO_FILE = "cvmfsexec_dist_%s.tgz"
+CVMFSEXEC_DIR = "cvmfsexec"
+CVMFSEXEC_ATTR = "CVMFSEXEC_DIR"
+
 
 # these are in the submit dir, so they can be changed
 PARAMS_FILE = "params.cfg"

--- a/creation/lib/cgWParamDict.py
+++ b/creation/lib/cgWParamDict.py
@@ -320,28 +320,32 @@ class glideinMainDicts(cgWDictFile.glideinMainDicts):
         distros_loc = os.path.join(self.work_dir, "cvmfsexec/tarballs")
         # os.scandir() is more efficient with python 3.x
         distros = os.listdir(distros_loc)
-        for cvmfsexec_idx in range(len(distros)):  # TODO: os.scandir() is more efficient with python 3.x
-            distro_info = distros[cvmfsexec_idx].split("_")
-            distro_arch = (distro_info[3] + "_" + distro_info[4]).split(".")[0]
-            # register the tarball, but make download conditional to cond_name
-            cvmfsexec_fname = cWConsts.insert_timestr(cgWConsts.CVMFSEXEC_DISTRO_FILE % cvmfsexec_idx)
+        if len(distros) == 0:
+            print("distributions for cvmfsexec not found... Skipping tarball creation.")
+        else:
+            for cvmfsexec_idx in range(len(distros)):
+                distro_info = distros[cvmfsexec_idx].split("_")
+                print(distro_info)
+                distro_arch = (distro_info[3] + "_" + distro_info[4]).split(".")[0]
+                # register the tarball, but make download conditional to cond_name
+                cvmfsexec_fname = cWConsts.insert_timestr(cgWConsts.CVMFSEXEC_DISTRO_FILE % cvmfsexec_idx)
 
-            platform = f"{distro_info[1]}-{distro_info[2]}-{distro_arch}"
-            cvmfsexec_cond_name = "CVMFSEXEC_PLATFORM_%s" % platform
-            cvmfsexec_platform_fname = cgWConsts.CVMFSEXEC_DISTRO_FILE % platform
+                platform = f"{distro_info[1]}-{distro_info[2]}-{distro_arch}"
+                cvmfsexec_cond_name = "CVMFSEXEC_PLATFORM_%s" % platform
+                cvmfsexec_platform_fname = cgWConsts.CVMFSEXEC_DISTRO_FILE % platform
 
-            self.dicts["file_list"].add_from_file(
-                cvmfsexec_platform_fname,
-                cWDictFile.FileDictFile.make_val_tuple(
-                    cvmfsexec_fname, "untar", cond_download=cvmfsexec_cond_name, config_out=cgWConsts.CVMFSEXEC_ATTR
-                ),
-                os.path.join(distros_loc, distros[cvmfsexec_idx]),
-            )
+                self.dicts["file_list"].add_from_file(
+                    cvmfsexec_platform_fname,
+                    cWDictFile.FileDictFile.make_val_tuple(
+                        cvmfsexec_fname, "untar", cond_download=cvmfsexec_cond_name, config_out=cgWConsts.CVMFSEXEC_ATTR
+                    ),
+                    os.path.join(distros_loc, distros[cvmfsexec_idx]),
+                )
 
-            self.dicts["untar_cfg"].add(cvmfsexec_platform_fname, cgWConsts.CVMFSEXEC_DIR)
-            # Add cond_name in the config, so that it is known
-            # But leave it disabled by default
-            self.dicts["consts"].add(cvmfsexec_cond_name, "0", allow_overwrite=False)
+                self.dicts["untar_cfg"].add(cvmfsexec_platform_fname, cgWConsts.CVMFSEXEC_DIR)
+                # Add cond_name in the config, so that it is known
+                # But leave it disabled by default
+                self.dicts["consts"].add(cvmfsexec_cond_name, "0", allow_overwrite=False)
         # end of "Add cvmfsexec" block
 
         # make sure condor_startup does not get executed ahead of time under normal circumstances

--- a/creation/lib/cgWParamDict.py
+++ b/creation/lib/cgWParamDict.py
@@ -311,7 +311,9 @@ class glideinMainDicts(cgWDictFile.glideinMainDicts):
         dist_select_script = "cvmfsexec_platform_select.sh"
         self.dicts["file_list"].add_from_file(
             dist_select_script,
-            cWDictFile.FileDictFile.make_val_tuple(cWConsts.insert_timestr(dist_select_script), "exec"),
+            cWDictFile.FileDictFile.make_val_tuple(
+                cWConsts.insert_timestr(dist_select_script), "exec", cond_download="GLIDEIN_USE_CVMFSEXEC"
+            ),
             os.path.join(cgWConsts.WEB_BASE_DIR, dist_select_script),
         )
 

--- a/creation/lib/cgWParamDict.py
+++ b/creation/lib/cgWParamDict.py
@@ -317,7 +317,8 @@ class glideinMainDicts(cgWDictFile.glideinMainDicts):
         )
 
         # get the location of the tarballs created during reconfig/upgrade
-        distros_loc = os.path.abspath("/tmp/cvmfsexec_pkg/tarballs")
+        distros_loc = os.path.join(self.work_dir, "cvmfsexec/tarballs")
+        # os.scandir() is more efficient with python 3.x
         distros = os.listdir(distros_loc)
         for cvmfsexec_idx in range(len(distros)):  # TODO: os.scandir() is more efficient with python 3.x
             distro_info = distros[cvmfsexec_idx].split("_")

--- a/creation/lib/cgWParamDict.py
+++ b/creation/lib/cgWParamDict.py
@@ -297,15 +297,51 @@ class glideinMainDicts(cgWDictFile.glideinMainDicts):
         self.dicts["untar_cfg"].add(pychirp_tarball, "lib/python/htchirp")
 
         # Add cvmfsexec
-        cvmfsexec_tarball = "cvmfs_utils.tar.gz"
+        cvmfsexec_utils = "cvmfs_utils.tar.gz"
         self.dicts["file_list"].add_from_file(
-            cvmfsexec_tarball,
+            cvmfsexec_utils,
             cWDictFile.FileDictFile.make_val_tuple(
-                cWConsts.insert_timestr(cvmfsexec_tarball), "untar", cond_download="GLIDEIN_USE_CVMFSEXEC"
+                cWConsts.insert_timestr(cvmfsexec_utils), "untar", cond_download="GLIDEIN_USE_CVMFSEXEC"
             ),
-            os.path.join(cgWConsts.WEB_BASE_DIR, cvmfsexec_tarball),
+            os.path.join(cgWConsts.WEB_BASE_DIR, cvmfsexec_utils),
         )
-        self.dicts["untar_cfg"].add(cvmfsexec_tarball, "cvmfs_utils")
+        self.dicts["untar_cfg"].add(cvmfsexec_utils, "cvmfs_utils")
+
+        # adding cvmfsexec distribution tarballs to the default list of uploads
+        # NOTE: the distribution tarballs are created during factory reconfig or upgrade
+        dist_select_script = "cvmfsexec_platform_select.sh"
+        self.dicts["file_list"].add_from_file(
+            dist_select_script,
+            cWDictFile.FileDictFile.make_val_tuple(cWConsts.insert_timestr(dist_select_script), "exec"),
+            os.path.join(cgWConsts.WEB_BASE_DIR, dist_select_script),
+        )
+
+        # get the location of the tarballs created during reconfig/upgrade
+        distros_loc = os.path.abspath("/tmp/cvmfsexec_pkg/tarballs")
+        distros = os.listdir(distros_loc)
+        for cvmfsexec_idx in range(len(distros)):  # TODO: os.scandir() is more efficient with python 3.x
+            distro_info = distros[cvmfsexec_idx].split("_")
+            distro_arch = (distro_info[3] + "_" + distro_info[4]).split(".")[0]
+            # register the tarball, but make download conditional to cond_name
+            cvmfsexec_fname = cWConsts.insert_timestr(cgWConsts.CVMFSEXEC_DISTRO_FILE % cvmfsexec_idx)
+
+            platform = f"{distro_info[1]}-{distro_info[2]}-{distro_arch}"
+            cvmfsexec_cond_name = "CVMFSEXEC_PLATFORM_%s" % platform
+            cvmfsexec_platform_fname = cgWConsts.CVMFSEXEC_DISTRO_FILE % platform
+
+            self.dicts["file_list"].add_from_file(
+                cvmfsexec_platform_fname,
+                cWDictFile.FileDictFile.make_val_tuple(
+                    cvmfsexec_fname, "untar", cond_download=cvmfsexec_cond_name, config_out=cgWConsts.CVMFSEXEC_ATTR
+                ),
+                os.path.join(distros_loc, distros[cvmfsexec_idx]),
+            )
+
+            self.dicts["untar_cfg"].add(cvmfsexec_platform_fname, cgWConsts.CVMFSEXEC_DIR)
+            # Add cond_name in the config, so that it is known
+            # But leave it disabled by default
+            self.dicts["consts"].add(cvmfsexec_cond_name, "0", allow_overwrite=False)
+        # end of "Add cvmfsexec" block
 
         # make sure condor_startup does not get executed ahead of time under normal circumstances
         # but must be loaded early, as it also works as a reporting script in case of error

--- a/creation/lib/cgWParamDict.py
+++ b/creation/lib/cgWParamDict.py
@@ -297,18 +297,17 @@ class glideinMainDicts(cgWDictFile.glideinMainDicts):
         self.dicts["untar_cfg"].add(pychirp_tarball, "lib/python/htchirp")
 
         # Add cvmfsexec
-        cvmfsexec_utils = "cvmfs_utils.tar.gz"
+        # Add cvmfsexec helper script enabled by conditional download
+        cvmfs_helper = "cvmfs_helper_funcs.sh"
         self.dicts["file_list"].add_from_file(
-            cvmfsexec_utils,
+            cvmfs_helper,
             cWDictFile.FileDictFile.make_val_tuple(
-                cWConsts.insert_timestr(cvmfsexec_utils), "untar", cond_download="GLIDEIN_USE_CVMFSEXEC"
+                cWConsts.insert_timestr(cvmfs_helper), "exec", cond_download="GLIDEIN_USE_CVMFSEXEC"
             ),
-            os.path.join(cgWConsts.WEB_BASE_DIR, cvmfsexec_utils),
+            os.path.join(cgWConsts.WEB_BASE_DIR, cvmfs_helper),
         )
-        self.dicts["untar_cfg"].add(cvmfsexec_utils, "cvmfs_utils")
 
-        # adding cvmfsexec distribution tarballs to the default list of uploads
-        # NOTE: the distribution tarballs are created during factory reconfig or upgrade
+        ### for dynamic selection of cvmfsexec distribution -- block start
         dist_select_script = "cvmfsexec_platform_select.sh"
         self.dicts["file_list"].add_from_file(
             dist_select_script,
@@ -316,16 +315,17 @@ class glideinMainDicts(cgWDictFile.glideinMainDicts):
             os.path.join(cgWConsts.WEB_BASE_DIR, dist_select_script),
         )
 
+        # TODO: update the following line to use the temporary location of the tarballs
+        # TODO: currently uses the 'cvmfsexec' dir inside creation/web-base
+        # TODO: the 'cvmfsexec' dir has all the tarballs created as a result of running 'generate_cvmfsexec_distros.sh'
         # get the location of the tarballs created during reconfig/upgrade
         distros_loc = os.path.join(self.work_dir, "cvmfsexec/tarballs")
-        # os.scandir() is more efficient with python 3.x
         distros = os.listdir(distros_loc)
         if len(distros) == 0:
-            print("distributions for cvmfsexec not found... Skipping tarball creation.")
+            print("Distributions for cvmfsexec not found... Skipping tarball creation.")
         else:
-            for cvmfsexec_idx in range(len(distros)):
+            for cvmfsexec_idx in range(len(distros)):  # TODO: os.scandir() is more efficient with python 3.x
                 distro_info = distros[cvmfsexec_idx].split("_")
-                print(distro_info)
                 distro_arch = (distro_info[3] + "_" + distro_info[4]).split(".")[0]
                 # register the tarball, but make download conditional to cond_name
                 cvmfsexec_fname = cWConsts.insert_timestr(cgWConsts.CVMFSEXEC_DISTRO_FILE % cvmfsexec_idx)
@@ -346,7 +346,7 @@ class glideinMainDicts(cgWDictFile.glideinMainDicts):
                 # Add cond_name in the config, so that it is known
                 # But leave it disabled by default
                 self.dicts["consts"].add(cvmfsexec_cond_name, "0", allow_overwrite=False)
-        # end of "Add cvmfsexec" block
+        ### for dynamic selection of cvmfsexec distribution -- block end
 
         # make sure condor_startup does not get executed ahead of time under normal circumstances
         # but must be loaded early, as it also works as a reporting script in case of error

--- a/creation/web_base/cvmfs_helper_funcs.sh
+++ b/creation/web_base/cvmfs_helper_funcs.sh
@@ -230,14 +230,6 @@ mount_cvmfs_repos () {
         # repositories (colon-delimited string)
         # RETURN(S): Mounts the defined repositories on the worker node filesystem
 
-	# QUESTION FOR MARCO
-	# see if the utilities are available (in the hidden directory) from the previous mount activity on the worker node
-	# this is not possible since this script is run once at the time of glidein creation on the worker node - is that right???
-	#if [[ ! -d $cvmfs_utils_dir/.cvmfsexec ]]; then
-	#	$cvmfs_utils_dir/mycvmfsexec -- echo "CVMFS utilities available" &> /dev/null
-	#	echo "executing inside"
-	#fi
-
 	$glidein_cvmfsexec_dir/$dist_file $1 -- echo "setting up mount utilities..." &> /dev/null
 	if [[ $(df -h|grep /cvmfs|wc -l) -eq 1 ]]; then
 		loginfo "CVMFS config repo already mounted!"
@@ -335,10 +327,6 @@ has_fuse() {
 	# make sure that perform_system_check has run
 	[[ -n "${GWMS_SYSTEM_CHECK}" ]] && perform_system_check
 
-	#GWMS_IS_FUSERMOUNT=0
-	#res_is_fusermount=$(check_exit_status $GWMS_IS_FUSERMOUNT)
-	#loginfo "fusermount available: $res_is_fusermount"
-
 	# check what specific configuration of unprivileged user namespaces exists in the system (worker node)
 	unpriv_userns_config=$(has_unpriv_userns)
 
@@ -433,8 +421,6 @@ perform_cvmfs_mount () {
 
         # perform checks on the worker node that will be used to assess whether CVMFS can be mounted or not
         perform_system_check
-
-        #loginfo "Start log for mounting CVMFS"
 
         # print/display all information pertaining to system checks performed previously (facilitates easy troubleshooting)
         log_all_system_info

--- a/creation/web_base/cvmfs_setup.sh
+++ b/creation/web_base/cvmfs_setup.sh
@@ -65,7 +65,6 @@ arch=$GWMS_OS_KRNL_ARCH
 dist_file=cvmfsexec-${cvmfs_source}-${os_like}${os_ver}-${arch}
 # the appropriate distribution file does not have to manually untarred as the glidein setup takes care of this automatically
 
-# TODO: Is this file somewhere in the source tree? use: # shellcheck source=./cvmfs_mount.sh
 perform_cvmfs_mount
 
 if [[ $GWMS_IS_CVMFS -ne 0 ]]; then

--- a/creation/web_base/cvmfs_utils.tar.gz
+++ b/creation/web_base/cvmfs_utils.tar.gz
@@ -1,1 +1,0 @@
-../../bigfiles/cvmfs_utils.tar.gz

--- a/creation/web_base/cvmfsexec_platform_select.sh
+++ b/creation/web_base/cvmfsexec_platform_select.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2009 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
+usage() {
+	echo "This script is used to generate cvmfsexec distributions for all"
+	echo "supported machine types (platform- and architecture-based)."
+	echo "The script takes one parameter {osg|egi|default} which specifies"
+	echo "the source to download the latest cvmfs configuration and repositories."
+}
+
+glidein_config=$1
+
+error_gen=`grep '^ERROR_GEN_PATH ' $glidein_config | awk '{print $2}'`
+
+# parameter is 'osg', 'egi' or 'default' to download the latest cvmfs and configuration
+# rpm from one of these three sources (Ref. https://www.github.com/cvmfs/cvmfsexec)
+cvmfs_src=`grep '^CVMFS_SRC ' $glidein_config | awk '{print $2}'`
+cvmfs_src=${cvmfs_src,,}
+
+# check if the value of cvmfs_src is valid
+if [[ ! $cvmfs_src =~ ^(osg|egi|default)$ ]]; then
+    echo "Invalid command line argument: Must be one of {osg, egi, default}"
+    "$error_gen" -error "`basename $0`" "fail_msg" "Invalid command line argument: Must be one of {osg, egi, default}"
+    exit 1
+fi
+
+# import add_config_line function
+add_config_line_source=`grep '^ADD_CONFIG_LINE_SOURCE ' $glidein_config | awk '{print $2}'`
+source $add_config_line_source
+
+# TODO: is it possible to reuse cvmfs_helper_funcs.sh by sourcing it during the execution of this file????
+if [ -f '/etc/redhat-release' ]; then
+    os_distro=rhel
+else
+    os_distro=non-rhel
+fi
+
+os_ver=`lsb_release -r | awk -F'\t' '{print $2}' | awk -F"." '{print $1}'`
+krnl_arch=`arch`
+mach_type=${os_distro}${os_ver}-${krnl_arch}
+
+cvmfsexec_platform="${cvmfs_src}-${mach_type}"
+cvmfsexec_platform_id="CVMFSEXEC_PLATFORM_$cvmfsexec_platform"
+
+# add the attribute to enable the appropriate distro file
+add_config_line "$cvmfsexec_platform_id" "1"
+
+# if everything goes well, report the good part too!
+"$error_gen" -ok "`basename $0`" "Cvmfsexec_platform" "${cvmfs_src}-${mach_type}"
+
+exit 0


### PR DESCRIPTION
Instead of shipping a large tarball with all possible combinations of distributions, one per platform architecture, evaluate the worker node to determine the system information and dynamically create a cvmfs distribution for the underlying platform and architecture.